### PR TITLE
Move phonetype enum class into separate enum folder

### DIFF
--- a/UHResidentInformationAPI/V1/Boundary/Responses/Phone.cs
+++ b/UHResidentInformationAPI/V1/Boundary/Responses/Phone.cs
@@ -1,3 +1,5 @@
+using UHResidentInformationAPI.V1.Enums;
+
 namespace UHResidentInformationAPI.V1.Boundary.Responses
 {
     public class Phone

--- a/UHResidentInformationAPI/V1/Enums/PhoneType.cs
+++ b/UHResidentInformationAPI/V1/Enums/PhoneType.cs
@@ -1,4 +1,4 @@
-namespace UHResidentInformationAPI.V1.Boundary.Responses
+namespace UHResidentInformationAPI.V1.Enums
 {
     public enum PhoneType
     {


### PR DESCRIPTION
This would be used in both the response object and in the domain object.

Moving this file into a separate folder for enums might make it clearer and more descriptive.
Rather than having it under the `boundary.responses` namespace.