### PR TITLE
Attempting some changes to see if we get performance boosts in Lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
       - run:
           name: Run formatter check
-          command: ./dotnet-format-local/dotnet-format --dry-run --check
+          command: ./dotnet-format-local/dotnet-format --check
   build-and-test:
     executor: docker-python
     steps:

--- a/HousingResidentInformationAPI/HousingResidentInformationAPI.csproj
+++ b/HousingResidentInformationAPI/HousingResidentInformationAPI.csproj
@@ -9,7 +9,6 @@
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-		<PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
 
   <ItemGroup>

--- a/HousingResidentInformationAPI/HousingResidentInformationAPI.csproj
+++ b/HousingResidentInformationAPI/HousingResidentInformationAPI.csproj
@@ -9,6 +9,7 @@
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+		<PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
 
   <ItemGroup>

--- a/HousingResidentInformationAPI/build.sh
+++ b/HousingResidentInformationAPI/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/housing-resident-information-api.zip
+dotnet lambda package --configuration release --framework netcoreapp3.1 --msbuild-parameters "/p:PublishReadyToRun=true /p:TieredCompilation=false /p:TieredCompilationQuickJit=false" --output-package ./bin/release/netcoreapp3.1/housing-resident-information-api.zip


### PR DESCRIPTION
## Seeing if we get a performance boost from setting ReadyToRun in the build command

### *What is the problem we're trying to solve*

.Net Core has a cold start problem and Setting ReadyToRun=true may improve the performance of our Lambdas when they're first called.

### *What changes have we introduced*

Removal of  --dry run from the formatting command as it's deprecated and breaks the command.

Additional build commands which may give us a performance boost when our Lambdas first launch.
